### PR TITLE
Load extensions from symlinked directories

### DIFF
--- a/lib/sensu/extensions/loader.rb
+++ b/lib/sensu/extensions/loader.rb
@@ -80,7 +80,7 @@ module Sensu
       def load_directory(directory)
         warning("loading extension files from directory", :directory => directory)
         path = directory.gsub(/\\(?=\S)/, "/")
-        Dir.glob(File.join(path, "**/*.rb")).each do |file|
+        Dir.glob(File.join(path, "**{,/*/**}/*.rb")).each do |file|
           load_file(file)
         end
       end

--- a/sensu-extensions.gemspec
+++ b/sensu-extensions.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "bouncy-castle-java" if RUBY_PLATFORM == "java"
 end

--- a/spec/assets/extensions-symlinked/symlinked_check.rb
+++ b/spec/assets/extensions-symlinked/symlinked_check.rb
@@ -1,0 +1,17 @@
+module Sensu
+  module Extension
+    class SymlinkedCheck < Check
+      def name
+        "symlinked_check"
+      end
+
+      def description
+        "returns 'foo'"
+      end
+
+      def run
+        yield 'foo', 0
+      end
+    end
+  end
+end

--- a/spec/assets/extensions/extensions-symlinked
+++ b/spec/assets/extensions/extensions-symlinked
@@ -1,0 +1,1 @@
+../extensions-symlinked

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -40,14 +40,14 @@ describe "Sensu::Extensions" do
 
   it "can load extensions from a directory" do
     extensions = Sensu::Extensions.load(:extension_dir => @extension_dir)
-    expect(extensions.loaded_files.size).to eq(2)
+    expect(extensions.loaded_files.size).to eq(3)
     expect(extensions.handler_exists?("test")).to be(true)
     expect(extensions.check_exists?("mock_check")).to be(true)
   end
 
   it "can load extensions from one or more directories" do
     extensions = Sensu::Extensions.load(:extension_dirs => [@extension_dir])
-    expect(extensions.loaded_files.size).to eq(2)
+    expect(extensions.loaded_files.size).to eq(3)
     expect(extensions.handler_exists?("test")).to be(true)
     expect(extensions.check_exists?("mock_check")).to be(true)
   end

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -39,10 +39,10 @@ describe "Sensu::Extensions::Loader" do
     expect(@loader.loaded_files).to be_empty
   end
 
-  it "can load extensions from a directory" do
+  it "can load extensions from a directory containing directory symlinks" do
     @loader.load_directory(@extension_dir)
-    expect(@loader.warnings.size).to eq(6)
-    expect(@loader.loaded_files.size).to eq(2)
+    expect(@loader.warnings.size).to eq(7)
+    expect(@loader.loaded_files.size).to eq(3)
     extension = Sensu::Extension::Test.new
     expect(extension).to respond_to(:name, :description, :definition, :safe_run, :stop, :has_key?, :[])
     extension = Sensu::Extension::MockCheck.new


### PR DESCRIPTION
Some organizations keep their Sensu plugins in a single repository, and would like to use symlinks into that repository's checkout directory instead of copying files into the Sensu extension dir. Support loading
extensions from directories symlinked into configured extension dirs to facilitate this.