### PR TITLE
added built-in silence_stashes filter

### DIFF
--- a/lib/sensu/extensions/filters/silence_stashes.rb
+++ b/lib/sensu/extensions/filters/silence_stashes.rb
@@ -1,0 +1,79 @@
+require "sensu/extension"
+require "em-http-request"
+
+module Sensu
+  module Extension
+    class SilenceStashes < Filter
+      def name
+        "silence_stashes"
+      end
+
+      def description
+        "filter events using api silence stashes"
+      end
+
+      def run(event)
+        event_silenced?(event) do |silenced|
+          if silenced
+            yield "event silenced by an api silence stash", 0
+          else
+            yield "event not silenced by an api silence stash", 1
+          end
+        end
+      end
+
+      private
+
+      def options
+        return @options if @options
+        @options = settings[:api] || {}
+        @options[:host] ||= "127.0.0.1"
+        @options[:port] ||= 4567
+        @options
+      end
+
+      def async_api_stash_request(stash_path)
+        connection_options = {
+          :connect_timeout => 10,
+          :inactivity_timeout => 10
+        }
+        request_options = {:path => "/stashes/" + stash_path}
+        if options[:user] && options[:password]
+          request_options[:head] = {
+            :authorization => [options[:user], options[:password]]
+          }
+        end
+        url = "http://#{options[:host]}:#{options[:port]}"
+        EM::HttpRequest.new(url, connection_options).get(request_options)
+      end
+
+      def silence_stash_exists?(stash_path, &callback)
+        http = async_api_stash_request(stash_path)
+        http.errback do
+          @logger.error("failed to query api for silence stash", :stash => stash_path)
+          callback.call(false)
+        end
+        http.callback do
+          exists = (http.response_header.status == 200)
+          callback.call(exists)
+        end
+      end
+
+      def event_silenced?(event, &callback)
+        client_stash = ["silence", event[:client][:name]].join("/")
+        check_stash = [client_stash, event[:check][:name]].join("/")
+        silence_stash_exists?(client_stash) do |exists|
+          if exists
+            @logger.debug("silence stash exists for client", :stash => client_stash)
+            callback.call(true)
+          else
+            silence_stash_exists?(check_stash) do |exists|
+              @logger.debug("silence stash exists for check", :stash => check_stash) if exists
+              callback.call(exists)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sensu-extensions.gemspec
+++ b/sensu-extensions.gemspec
@@ -21,11 +21,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sensu-extension"
 
   spec.add_dependency "multi_json"
+  spec.add_dependency "em-http-request"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "uuidtools"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "bouncy-castle-java" if RUBY_PLATFORM =~ /java/
   spec.add_development_dependency "codeclimate-test-reporter" unless RUBY_VERSION < "1.9"
 end

--- a/spec/filters/silence_stashes_spec.rb
+++ b/spec/filters/silence_stashes_spec.rb
@@ -1,0 +1,69 @@
+require File.join(File.dirname(__FILE__), "..", "helpers")
+require "webmock/rspec"
+
+require "sensu/extensions/filters/silence_stashes"
+
+describe "Sensu::Extension::SilenceStashes" do
+  include Helpers
+
+  before do
+    @extension = Sensu::Extension::SilenceStashes.new
+    @extension.logger = Sensu::Logger.get
+    @extension.settings = {}
+    stub_request(:get, %r(127\.0\.0\.1:4567/stashes/silence/.*)).
+      to_return(:status => 404)
+  end
+
+  it "can run, not filtering the event by default" do
+    async_wrapper do
+      event = event_template
+      @extension.safe_run(event) do |output, status|
+        expect(output).to eq("event not silenced by an api silence stash")
+        expect(status).to eq(1)
+        async_done
+      end
+    end
+  end
+
+  it "can determine if an event is silenced for a client" do
+    async_wrapper do
+      event = event_template
+      @extension.safe_run(event) do |output, status|
+        expect(status).to eq(1)
+        stub_request(:get, "127.0.0.1:4567/stashes/silence/foo").
+          to_return(:status => 200)
+        @extension.safe_run(event) do |output, status|
+          expect(status).to eq(1)
+          stub_request(:get, "127.0.0.1:4567/stashes/silence/i-424242").
+            to_return(:status => 200)
+          @extension.safe_run(event) do |output, status|
+            expect(status).to eq(0)
+            expect(output).to eq("event silenced by an api silence stash")
+            async_done
+          end
+        end
+      end
+    end
+  end
+
+  it "can determine if an event is silenced for a client check" do
+    async_wrapper do
+      event = event_template
+      @extension.safe_run(event) do |output, status|
+        expect(status).to eq(1)
+        stub_request(:get, "127.0.0.1:4567/stashes/silence/i-424242/foo").
+          to_return(:status => 200)
+        @extension.safe_run(event) do |output, status|
+          expect(status).to eq(1)
+          stub_request(:get, "127.0.0.1:4567/stashes/silence/i-424242/test").
+            to_return(:status => 200)
+          @extension.safe_run(event) do |output, status|
+            expect(status).to eq(0)
+            expect(output).to eq("event silenced by an api silence stash")
+            async_done
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This filter/functionality is currently available in Sensu Enterprise http://sensuapp.org/docs/0.17/enterprise-built-in-filters#silencestashes I've reimplemented it to work with Sensu Core. We at HW believe this built-in filter should be available in Sensu Core.