### PR TITLE
Add sensu-extensions-deregistration handler

### DIFF
--- a/lib/sensu/extensions/loader.rb
+++ b/lib/sensu/extensions/loader.rb
@@ -4,6 +4,7 @@ gem "sensu-extensions-json", "1.0.0"
 gem "sensu-extensions-ruby-hash", "1.0.0"
 gem "sensu-extensions-only-check-output", "1.0.0"
 gem "sensu-extensions-debug", "1.0.0"
+gem "sensu-extensions-deregistration", "1.0.0"
 
 require "sensu/extension"
 require "sensu/extensions/constants"
@@ -13,6 +14,7 @@ require "sensu/extensions/json"
 require "sensu/extensions/ruby-hash"
 require "sensu/extensions/only-check-output"
 require "sensu/extensions/debug"
+require "sensu/extensions/deregistration"
 
 module Sensu
   module Extensions

--- a/sensu-extensions.gemspec
+++ b/sensu-extensions.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sensu-extensions-ruby-hash", "1.0.0"
   spec.add_dependency "sensu-extensions-only-check-output", "1.0.0"
   spec.add_dependency "sensu-extensions-debug", "1.0.0"
+  spec.add_dependency "sensu-extensions-deregistration", "1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -59,6 +59,7 @@ describe "Sensu::Extensions" do
     expect(extensions.mutator_exists?("ruby_hash")).to be(true)
     expect(extensions.mutator_exists?("only_check_output")).to be(true)
     expect(extensions.handler_exists?("debug")).to be(true)
+    expect(extensions.handler_exists?("deregistration")).to be(true)
   end
 
   it "can load extensions from gems" do

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -67,6 +67,7 @@ describe "Sensu::Extensions::Loader" do
     expect(@loader.mutator_exists?("json")).to be(true)
     expect(@loader.mutator_exists?("ruby_hash")).to be(true)
     expect(@loader.mutator_exists?("only_check_output")).to be(true)
+    expect(@loader.handler_exists?("deregistration")).to be(true)
   end
 
   it "can load instances of the built-in and loaded extensions" do


### PR DESCRIPTION
Adds the sensu-extensions-deregistration handler.

I had to remove the version constraint on activesupport as github_changelog_generator now requires a newer version.

Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>